### PR TITLE
[SDKv2] Add Account support for secp256k1 scheme

### DIFF
--- a/ecosystem/typescript/sdk_v2/src/core/account.ts
+++ b/ecosystem/typescript/sdk_v2/src/core/account.ts
@@ -66,7 +66,7 @@ export class Account {
       // Secp256k1
       this.signingScheme = SigningScheme.Secp256k1Ecdsa;
     } else {
-      throw new Error("Unsupported public key type");
+      throw new Error("Can not create new Account, unsupported public key type");
     }
 
     this.privateKey = privateKey;
@@ -76,19 +76,22 @@ export class Account {
   /**
    * Derives an account with random private key and address
    *
-   * @param args.scheme AuthenticationKeyScheme - type of Authentication Key schemes
+   * @param args.scheme SigningScheme - type of SigningScheme to use.
+   * Currently only Ed25519, MultiEd25519, and Secp256k1 are supported
+   *
    * @returns Account
    */
   static generate(args: { scheme: SigningScheme }): Account {
+    const { scheme } = args;
     let privateKey: PrivateKey;
 
-    if (args.scheme === SigningScheme.Ed25519) {
+    if (scheme === SigningScheme.Ed25519) {
       privateKey = Ed25519PrivateKey.generate();
-    } else if (args.scheme === SigningScheme.Secp256k1Ecdsa) {
+    } else if (scheme === SigningScheme.Secp256k1Ecdsa) {
       privateKey = Secp256k1PrivateKey.generate();
     } else {
       // TODO: Add support for MultiEd25519
-      throw new Error("Unsupported signing scheme");
+      throw new Error(`Can not generate new Private Key, unsupported signing scheme ${scheme}`);
     }
 
     const address = new AccountAddress({ data: Account.authKey({ publicKey: privateKey.publicKey() }).toUint8Array() });

--- a/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/authentication_key.ts
@@ -3,10 +3,11 @@
 
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { AccountAddress, Hex } from "../core";
-import { AuthenticationKeyScheme, HexInput } from "../types";
+import { AuthenticationKeyScheme, HexInput, SigningScheme } from "../types";
 import { MultiEd25519PublicKey } from "./multi_ed25519";
 import { PublicKey } from "./asymmetric_crypto";
 import { Ed25519PublicKey } from "./ed25519";
+import { Secp256k1PublicKey } from "./secp256k1";
 
 /**
  * Each account stores an authentication key. Authentication key enables account owners to rotate
@@ -75,9 +76,11 @@ export class AuthenticationKey {
 
     let scheme: number;
     if (publicKey instanceof Ed25519PublicKey) {
-      scheme = AuthenticationKeyScheme.Ed25519.valueOf();
+      scheme = SigningScheme.Ed25519.valueOf();
     } else if (publicKey instanceof MultiEd25519PublicKey) {
-      scheme = AuthenticationKeyScheme.MultiEd25519.valueOf();
+      scheme = SigningScheme.MultiEd25519.valueOf();
+    } else if (publicKey instanceof Secp256k1PublicKey) {
+      scheme = SigningScheme.Secp256k1Ecdsa.valueOf();
     } else {
       throw new Error("No supported authentication scheme for public key");
     }

--- a/ecosystem/typescript/sdk_v2/src/crypto/secp256k1.ts
+++ b/ecosystem/typescript/sdk_v2/src/crypto/secp256k1.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { sha256 } from "@noble/hashes/sha256";
+import { secp256k1 } from "@noble/curves/secp256k1";
 import { Deserializer, Serializer } from "../bcs";
 import { Hex } from "../core";
 import { HexInput } from "../types";
 import { PrivateKey, PublicKey, Signature } from "./asymmetric_crypto";
-import { secp256k1 } from "@noble/curves/secp256k1";
 
 /**
  * Represents the Secp256k1 ecdsa public key
@@ -161,11 +161,11 @@ export class Secp256k1PrivateKey extends PrivateKey {
 
   /**
    * Derive the Secp256k1PublicKey from this private key.
-   * 
+   *
    * @returns Secp256k1PublicKey
    */
   publicKey(): Secp256k1PublicKey {
-    const bytes = secp256k1.getPublicKey(this.key.toUint8Array());
+    const bytes = secp256k1.getPublicKey(this.key.toUint8Array(), false);
     return new Secp256k1PublicKey({ hexInput: bytes });
   }
 }

--- a/ecosystem/typescript/sdk_v2/src/types/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/types/index.ts
@@ -790,6 +790,8 @@ export type AuthenticationKeyScheme = SigningScheme | DeriveScheme;
 
 /**
  * A list of signing schemes that are supported by Aptos.
+ *
+ * https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/authenticator.rs#L375-L378
  */
 export enum SigningScheme {
   /**

--- a/ecosystem/typescript/sdk_v2/src/types/index.ts
+++ b/ecosystem/typescript/sdk_v2/src/types/index.ts
@@ -784,10 +784,14 @@ export type TableItemRequest = {
 /**
  * A list of Authentication Key schemes that are supported by Aptos.
  *
- * Keys that start with `Derive` are solely used for deriving account addresses from
- * other data. They are not used for signing transactions.
+ * They are combinations of signing schemes and derive schemes.
  */
-export enum AuthenticationKeyScheme {
+export type AuthenticationKeyScheme = SigningScheme | DeriveScheme;
+
+/**
+ * A list of signing schemes that are supported by Aptos.
+ */
+export enum SigningScheme {
   /**
    * For Ed25519PublicKey
    */
@@ -796,6 +800,16 @@ export enum AuthenticationKeyScheme {
    * For MultiEd25519PublicKey
    */
   MultiEd25519 = 1,
+  /**
+   * For Secp256k1 ecdsa
+   */
+  Secp256k1Ecdsa = 2,
+}
+
+/**
+ * Scheme used for deriving account addresses from other data
+ */
+export enum DeriveScheme {
   /**
    * Derives an address using an AUID, used for objects
    */

--- a/ecosystem/typescript/sdk_v2/tests/unit/account.test.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/account.test.ts
@@ -5,13 +5,16 @@ import { Account } from "../../src/core/account";
 import { AccountAddress } from "../../src/core/account_address";
 import { Hex } from "../../src/core/hex";
 import { Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
-import { ed25519 } from "./helper";
-import { PublicKey } from "../../src/crypto/asymmetric_crypto";
+import { Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1Signature } from "../../src/crypto/secp256k1";
+import { SigningScheme } from "../../src/types";
+import { ed25519, secp256k1TestObject, wallet } from "./helper";
 
-describe("Account", () => {
+describe("Ed25519 Account", () => {
   it("should create an instance of Account correctly without error", () => {
-    const account = Account.generate();
-    expect(account).toBeInstanceOf(Account);
+    // Account with Ed25519 scheme
+    const edAccount = Account.generate({ scheme: SigningScheme.Ed25519 });
+    expect(edAccount).toBeInstanceOf(Account);
+    expect(edAccount.signingScheme).toEqual(SigningScheme.Ed25519);
   });
 
   it("should create a new account from a provided private key", () => {
@@ -42,21 +45,19 @@ describe("Account", () => {
   });
 
   it("should create a new account from a bip44 path and mnemonics", () => {
-    const { mnemonic } = ed25519;
-    const address = "0x07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30";
-    const path = "m/44'/637'/0'/0'/0'";
+    const { mnemonic, address, path } = wallet;
     const newAccount = Account.fromDerivationPath({ path, mnemonic });
     expect(newAccount.accountAddress.toString()).toEqual(address);
   });
 
   it("should prevent an invalid bip44 path ", () => {
-    const { mnemonic } = ed25519;
+    const { mnemonic } = wallet;
     const path = "1234";
     expect(() => Account.fromDerivationPath({ path, mnemonic })).toThrow("Invalid derivation path");
   });
 
   it("should check if a derivation path is valid", () => {
-    const validPath = "m/44'/637'/0'/0'/0'"; // Valid path
+    const validPath = wallet.path; // Valid path
     const invalidPath = "invalid/path"; // Invalid path
     expect(Account.isValidPath({ path: validPath })).toBe(true);
     expect(Account.isValidPath({ path: invalidPath })).toBe(false);
@@ -82,5 +83,85 @@ describe("Account", () => {
     // Verify the signature
     const signature = new Ed25519Signature({ hexInput: signedMessage });
     expect(account.verifySignature({ message, signature })).toBe(true);
+  });
+});
+
+describe("Secp256k1 Account", () => {
+  it("should create an instance of Account correctly without error", () => {
+    // Account with Secp256k1 scheme
+    const secp256k1Account = Account.generate({ scheme: SigningScheme.Secp256k1Ecdsa });
+    expect(secp256k1Account).toBeInstanceOf(Account);
+    expect(secp256k1Account.signingScheme).toEqual(SigningScheme.Secp256k1Ecdsa);
+  });
+
+  it("should create a new account from a provided private key", () => {
+    const { privateKey: privateKeyBytes, publicKey, address } = secp256k1TestObject;
+    const privateKey = new Secp256k1PrivateKey({ hexInput: privateKeyBytes });
+    const newAccount = Account.fromPrivateKey({ privateKey });
+    expect(newAccount).toBeInstanceOf(Account);
+    expect((newAccount.privateKey as Secp256k1PrivateKey).toString()).toEqual(privateKey.toString());
+    expect((newAccount.publicKey as Secp256k1PublicKey).toString()).toEqual(
+      new Secp256k1PublicKey({ hexInput: publicKey }).toString(),
+    );
+    expect(newAccount.accountAddress.toString()).toEqual(address);
+  });
+
+  it("should create a new account from a provided private key and address", () => {
+    const { privateKey: privateKeyBytes, publicKey, address } = secp256k1TestObject;
+    const privateKey = new Secp256k1PrivateKey({ hexInput: privateKeyBytes });
+    const newAccount = Account.fromPrivateKeyAndAddress({
+      privateKey,
+      address: AccountAddress.fromString({ input: address }),
+    });
+    expect(newAccount).toBeInstanceOf(Account);
+    expect((newAccount.privateKey as Secp256k1PrivateKey).toString()).toEqual(privateKey.toString());
+    expect((newAccount.publicKey as Secp256k1PublicKey).toString()).toEqual(
+      new Secp256k1PublicKey({ hexInput: publicKey }).toString(),
+    );
+    expect(newAccount.accountAddress.toString()).toEqual(address);
+  });
+
+  it("should create a new account from a bip44 path and mnemonics", () => {
+    const { mnemonic, address, path } = wallet;
+    const newAccount = Account.fromDerivationPath({ path, mnemonic });
+    expect(newAccount.accountAddress.toString()).toEqual(address);
+  });
+
+  it("should prevent an invalid bip44 path ", () => {
+    const { mnemonic } = wallet;
+    const path = "1234";
+    expect(() => Account.fromDerivationPath({ path, mnemonic })).toThrow("Invalid derivation path");
+  });
+
+  it("should check if a derivation path is valid", () => {
+    const validPath = wallet.path; // Valid path
+    const invalidPath = "invalid/path"; // Invalid path
+    expect(Account.isValidPath({ path: validPath })).toBe(true);
+    expect(Account.isValidPath({ path: invalidPath })).toBe(false);
+  });
+
+  it("should return the authentication key for a public key", () => {
+    const { publicKey: publicKeyBytes, address } = secp256k1TestObject;
+    const publicKey = new Secp256k1PublicKey({ hexInput: publicKeyBytes });
+    const authKey = Account.authKey({ publicKey });
+    expect(authKey).toBeInstanceOf(Hex);
+    expect(authKey.toString()).toEqual(address);
+  });
+
+  it("should sign data, return a Hex signature, and verify", () => {
+    const { privateKey: privateKeyBytes, address, signatureHex, messageEncoded } = secp256k1TestObject;
+
+    // Sign the message
+    const secp256k1PrivateKey = new Secp256k1PrivateKey({ hexInput: privateKeyBytes });
+    const account = Account.fromPrivateKeyAndAddress({
+      privateKey: secp256k1PrivateKey,
+      address: AccountAddress.fromString({ input: address }),
+    });
+    const signedMessage = account.sign({ data: messageEncoded });
+    expect(signedMessage.toString()).toEqual(signatureHex);
+
+    // Verify the signature
+    const signature = new Secp256k1Signature({ hexInput: signatureHex });
+    expect(account.verifySignature({ message: messageEncoded, signature })).toBe(true);
   });
 });

--- a/ecosystem/typescript/sdk_v2/tests/unit/helper.ts
+++ b/ecosystem/typescript/sdk_v2/tests/unit/helper.ts
@@ -1,13 +1,18 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+export const wallet = {
+  address: "0x07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30",
+  mnemonic: "shoot island position soft burden budget tooth cruel issue economy destroy above",
+  path: "m/44'/637'/0'/0'/0'",
+};
+
 /* eslint-disable max-len */
 export const ed25519 = {
   privateKey: "0xc5338cd251c22daa8c9c9cc94f498cc8a5c7e1d2e75287a5dda91096fe64efa5",
   publicKey: "0xde19e5d1880cac87d57484ce9ed2e84cf0f9599f12e7cc3a52e4e7657a763f2c",
   authKey: "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",
   address: "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",
-  mnemonic: "shoot island position soft burden budget tooth cruel issue economy destroy above",
   message: "0x7777",
   signedMessage:
     "0xc5de9e40ac00b371cd83b1c197fa5b665b7449b33cd3cdd305bb78222e06a671a49625ab9aea8a039d4bb70e275768084d62b094bc1b31964f2357b7c1af7e0d",
@@ -38,6 +43,8 @@ export const secp256k1TestObject = {
   privateKey: "0xd107155adf816a0a94c6db3c9489c13ad8a1eda7ada2e558ba3bfa47c020347e",
   publicKey:
     "0x04acdd16651b839c24665b7e2033b55225f384554949fef46c397b5275f37f6ee95554d70fb5d9f93c5831ebf695c7206e7477ce708f03ae9bb2862dc6c9e033ea",
+  address: "0x44b9b90a0bd6a691a20cb06148f10ec9c21da63bb5df345ae38507e0c3c2f897",
+  authKey: "0x44b9b90a0bd6a691a20cb06148f10ec9c21da63bb5df345ae38507e0c3c2f897",
   messageEncoded: "68656c6c6f20776f726c64", // "hello world"
   signatureHex:
     "0x3eda29841168c902b154ac12dfb0f8775ece1b95315b227ede64cbd715abac665aa8c8df5b108b0d4918bb88ea58c892972af375a71761a7e590655ff5de3859",


### PR DESCRIPTION
### Description

Prev stack - https://github.com/aptos-labs/aptos-core/pull/10321

This PR updates the `Account` class to be compatible with `secp256k1` scheme.

1. Split the AuthenticationKey scheme into `SigningScheme` and `DeriveScheme`
2. Add Account support for `secp256k1` scheme
3. Update unit test

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

pnpm fmt
pnpm test